### PR TITLE
style: Agregar espacio adicional en main.dart (comentario de importacion)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,4 @@
-// lib/main.dart
+//  lib/main.dart
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';


### PR DESCRIPTION
- Cambio de "// lib/main.dart" a "// lib/main.dart"
- Este cambio no afecta la funcionalidad, solo agrega un espacio al comentario